### PR TITLE
feat: verify idle pattern and zero insertion

### DIFF
--- a/tb/assertions_hdlc.sv
+++ b/tb/assertions_hdlc.sv
@@ -43,6 +43,10 @@ module assertions_hdlc (
     !signal ##1 signal[*7]; // abort flag is 1111_1110
   endsequence
 
+  sequence Idle_Pattern(signal);
+    signal[*8]; // idle pattern is 1111_1111
+  endsequence
+
   /*******************************************
    * Verify correct Rx_FlagDetect behavior   *
    *******************************************/
@@ -127,5 +131,20 @@ module assertions_hdlc (
     ErrCntAssertions++;
   end
   
+  /********************************************
+   * Verify idle pattern generation           *
+   ********************************************/
+
+  property TX_IdlePattern;
+    @(posedge Clk)
+    !Tx_ValidFrame |-> Flag_Sequence(Tx) or Tx;
+  endproperty
+
+  TX_IdlePattern_Assert : assert property (TX_IdlePattern) begin 
+    $display("PASS: idle pattern generated on invalid TX frame");
+  end else begin
+    $error("idle pattern not generated on invalid TX frame");
+    ErrCntAssertions++;
+  end
 
 endmodule

--- a/tb/assertions_hdlc.sv
+++ b/tb/assertions_hdlc.sv
@@ -43,14 +43,11 @@ module assertions_hdlc (
   initial begin // TransmittingFrame is asserted during frame transmition, including flags
     while (1) begin
       wait(Tx_ValidFrame);
-
       TransmittingFrame = 0'b1;
 
       wait(!Tx_ValidFrame);
-
       repeat(9) // give time to generate end/abort flag
         @(posedge Clk);
-
       TransmittingFrame = 0'b0;
     end
   end
@@ -58,14 +55,11 @@ module assertions_hdlc (
   initial begin // TransmittingFrameContent is assert during frame transmition, not including flags
     while (1) begin
       wait(Tx_ValidFrame);
-
       repeat(10) // give time to generate start flag
         @(posedge Clk);
-
       TransmittingFrameContent = 0'b1;
 
       wait(!Tx_ValidFrame);
-
       TransmittingFrameContent = 0'b0;
     end
   end
@@ -80,10 +74,6 @@ module assertions_hdlc (
 
   sequence Abort_Flag(signal);
     !signal ##1 signal[*7]; // abort flag is 1111_1110
-  endsequence
-
-  sequence Idle_Pattern(signal);
-    signal[*8]; // idle pattern is 1111_1111
   endsequence
 
   /*******************************************
@@ -208,7 +198,7 @@ module assertions_hdlc (
   property TX_ValidFrameAssert;
     @(posedge Clk)
     // Tx_ValidFrame should always be asserted after Tx_Enable
-    // After Tx_ValidFrame is asserter there should always be generated a start flag
+    // After Tx_ValidFrame is asserted there should always be generated a start flag
     // unless the frame is aborted before transmission starts
     disable iff (Tx_AbortFrame)
     Tx_Enable |=> ##[0:$] Tx_ValidFrame ##1 Flag_Sequence(Tx);
@@ -221,16 +211,16 @@ module assertions_hdlc (
     !Tx_ValidFrame ##1 Tx_ValidFrame |=> ##[0:$] !Tx_ValidFrame ##1 (Flag_Sequence(Tx) or Abort_Flag(Tx));
   endproperty
 
-  TX_ValidFrameAssert_Assert : assert property (TX_ValidFrameAssert)
+  TX_ValidFrameAssert_Assert : assert property (TX_ValidFrameAssert) begin
     $display("Pass: Tx_ValidFrame asserted after Tx_Enable");
-  else begin
+  end else begin
     $error("FAIL: Tx_ValidFrame not asserted after Tx_Enable");
     ErrCntAssertions++;
   end
 
-  TX_ValidFrameDeassert_Assert : assert property (TX_ValidFrameDeassert)
+  TX_ValidFrameDeassert_Assert : assert property (TX_ValidFrameDeassert) begin
   $display("Pass: Tx_ValidFrame deasserted and end/abort flag generated");
-  else begin
+  end else begin
     $error("FAIL: Tx_ValidFrame not deasserted or end/abort flag not generated");
     ErrCntAssertions++;
   end

--- a/tb/bind_hdlc.sv
+++ b/tb/bind_hdlc.sv
@@ -20,7 +20,8 @@ module bind_hdlc ();
     .Rx_WrBuff        (uin_hdlc.Rx_WrBuff),
     .Tx_AbortFrame    (uin_hdlc.Tx_AbortFrame),
     .Tx_AbortedTrans  (uin_hdlc.Tx_AbortedTrans),
-    .Tx_ValidFrame    (uin_hdlc.Tx_ValidFrame)
+    .Tx_ValidFrame    (uin_hdlc.Tx_ValidFrame),
+    .Tx_Enable        (uin_hdlc.Tx_Enable)
   );
 
 endmodule

--- a/tb/bind_hdlc.sv
+++ b/tb/bind_hdlc.sv
@@ -20,7 +20,7 @@ module bind_hdlc ();
     .Rx_WrBuff        (uin_hdlc.Rx_WrBuff),
     .Tx_AbortFrame    (uin_hdlc.Tx_AbortFrame),
     .Tx_AbortedTrans  (uin_hdlc.Tx_AbortedTrans),
-    .Tx_ValidFrame  (uin_hdlc.Tx_ValidFrame)
+    .Tx_ValidFrame    (uin_hdlc.Tx_ValidFrame)
   );
 
 endmodule

--- a/tb/in_hdlc.sv
+++ b/tb/in_hdlc.sv
@@ -56,5 +56,6 @@ interface in_hdlc ();
   logic       Tx_AbortedTrans;
   logic       Tx_Done;
   logic       Tx_ValidFrame;
+  logic       Tx_Enable;
 
 endinterface

--- a/tb/testPr_hdlc.sv
+++ b/tb/testPr_hdlc.sv
@@ -232,7 +232,6 @@ program testPr_hdlc(
     Transmit( 42, 1, 0);            //Abort
 
     //Receive: Size, Abort, FCSerr, NonByteAligned, Overflow, Drop, SkipRead
-    /*
     Receive( 10, 0, 0, 0, 0, 0, 0); //Normal
     Receive( 40, 1, 0, 0, 0, 0, 0); //Abort
     Receive(126, 0, 0, 0, 1, 0, 0); //Overflow
@@ -247,7 +246,6 @@ program testPr_hdlc(
     Receive( 42, 0, 0, 0, 0, 1, 0); //FrameDropped
     Receive(  6, 0, 0, 0, 0, 0, 0); //Normal
     Receive( 33, 0, 0, 1, 0, 0, 0); //FrameError NonByteAligned
-    */
 
     $display("*************************************************************");
     $display("%t - Finishing Test Program", $time);

--- a/tb/testPr_hdlc.sv
+++ b/tb/testPr_hdlc.sv
@@ -232,6 +232,7 @@ program testPr_hdlc(
     Transmit( 42, 1, 0);            //Abort
 
     //Receive: Size, Abort, FCSerr, NonByteAligned, Overflow, Drop, SkipRead
+    /*
     Receive( 10, 0, 0, 0, 0, 0, 0); //Normal
     Receive( 40, 1, 0, 0, 0, 0, 0); //Abort
     Receive(126, 0, 0, 0, 1, 0, 0); //Overflow
@@ -246,13 +247,14 @@ program testPr_hdlc(
     Receive( 42, 0, 0, 0, 0, 1, 0); //FrameDropped
     Receive(  6, 0, 0, 0, 0, 0, 0); //Normal
     Receive( 33, 0, 0, 1, 0, 0, 0); //FrameError NonByteAligned
+    */
 
     $display("*************************************************************");
     $display("%t - Finishing Test Program", $time);
     $display("*************************************************************");
     $stop;
   end
-
+  
   final begin
 
     $display("*********************************");
@@ -382,9 +384,14 @@ program testPr_hdlc(
       WriteAddress(Tx_SC, 8'b1 << Tx_AbortFrame);
     end
 
+    wait(!uin_hdlc.Tx_Done); // wait for transmition completion
+
+    repeat(16)
+      @(posedge uin_hdlc.Clk);
+
     // TODO: insert immediate assertion tasks
 
-    #10000ns;
+    #1000000ns; // make sure all concurrent assertions finish
   endtask
 
   task Receive(int Size, int Abort, int FCSerr, int NonByteAligned, int Overflow, int Drop, int SkipRead);

--- a/tb/test_hdlc.sv
+++ b/tb/test_hdlc.sv
@@ -39,7 +39,8 @@ module test_hdlc ();
   assign uin_hdlc.ZeroDetect         = u_dut.u_RxChannel.ZeroDetect;
   assign uin_hdlc.Tx_AbortFrame      = u_dut.Tx_AbortFrame;
   assign uin_hdlc.Tx_AbortedTrans    = u_dut.Tx_AbortedTrans;
-  assign uin_hdlc.Tx_ValidFrame    = u_dut.Tx_ValidFrame;
+  assign uin_hdlc.Tx_ValidFrame      = u_dut.Tx_ValidFrame;
+  assign uin_hdlc.Tx_Enable          = u_dut.Tx_Enable;
 
   //Clock
   always #250ns uin_hdlc.Clk = ~uin_hdlc.Clk;


### PR DESCRIPTION
# Changes

- Add two local signals in the assertions file `TransmittingFrame` and `TransmittingFrameContent`. These are derived from the `Tx_ValidFrame` signal and are used when checking idle pattern generation and zero insertion.
- Verify zero insertion.
- Verify idle pattern generation.
- Verify correct behaviour of `Tx_ValidFrame`. This had to be done because we use the signal to derive the aforementioned signals.
- Zero removal and idle pattern detection are covered by the immediate assertions in the testbench.