### PR TITLE
feat: coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ transcript
 *.wlf
 .nfs*
 *.vstf
+coverage_rep.txt

--- a/tb/compile.sh
+++ b/tb/compile.sh
@@ -6,7 +6,7 @@ NC='\033[0m'
 vlib work 
 
 printf "${RED}\nCompiling design${NC}\n"
-if vlog -sv ../rtl/*.sv 
+if vlog +cover=bcefsx -sv ../rtl/*.sv 
 then
 	echo "Success"
 else
@@ -15,7 +15,7 @@ else
 fi
 
 printf "${RED}\nCompiling test files${NC}\n"
-if vlog -sv ./*.sv 
+if vlog +cover=bcefsx -sv ./*.sv 
 then
 	echo "Success"
 else

--- a/tb/coverage_hdlc.sv
+++ b/tb/coverage_hdlc.sv
@@ -1,0 +1,38 @@
+//////////////////////////////////////////////////
+// Title:   coverage_hdlc
+// Author: Aasmund and Mathias
+// Date: 19.04.2025 
+//////////////////////////////////////////////////
+
+module coverage_hdlc(
+  in_hdlc uin_hdlc
+);
+  covergroup hdlc_cg @(posedge uin_hdlc.Clk);
+    Tx_FrameSize_cp : coverpoint uin_hdlc.Tx_FrameSize {
+
+    }
+
+    Rx_FrameSize_cp : coverpoint uin_hdlc.Rx_FrameSize {
+
+    }
+
+    Tx_SC_cp : coverpoint uin_hdlc.Tx_SC {
+
+    }
+
+    Rx_SC_cp : coverpoint uin_hdlc.Rx_SC {
+
+    }
+  endgroup
+
+  //Initialize coverage group
+  hdlc_cg coverage_inst;
+  initial begin
+      coverage_inst = new();
+  end
+
+  always @(posedge uin_hdlc.Clk) begin
+    coverage_inst.sample();
+  end
+
+endmodule:coverage_hdlc

--- a/tb/coverage_hdlc.sv
+++ b/tb/coverage_hdlc.sv
@@ -4,27 +4,40 @@
 // Date: 19.04.2025 
 //////////////////////////////////////////////////
 
-`include "hdlc_packet.sv"
-
 module coverage_hdlc(
   in_hdlc uin_hdlc
 );
+  `include "hdlc_packet.sv"
+  
   covergroup hdlc_cg @(posedge uin_hdlc.Clk);
     Tx_FrameSize_cp : coverpoint uin_hdlc.Tx_FrameSize {
-      bins zero = {2}; // address + control + 0 data bytes
-      bins small_ = {[3:10]};
+      bins small_ = {[3:10]}; // address + control + 1 data byte
       bins large_ = {[100:$]};
       bins max = {126};
       bins others = default;
     }
 
     Rx_FrameSize_cp : coverpoint uin_hdlc.Rx_FrameSize {
-      bins zero = {2}; // address + control + 0 data bytes
-      bins small_ = {[3:10]};
+      bins small_ = {[3:10]}; // address + control + 1 data byte
       bins large_ = {[100:$]};
       bins max = {126};
       bins others = default;
     }
+
+    // Check all bits in Rx_SC register have been toggled
+    Rx_Ready_cp : coverpoint uin_hdlc.Rx_SC[Rx_Ready];
+    Rx_Drop_cp : coverpoint uin_hdlc.Rx_SC[Rx_Drop];
+    Rx_FrameError_cp : coverpoint uin_hdlc.Rx_SC[Rx_FrameError];
+    Rx_AbortSignal_cp : coverpoint uin_hdlc.Rx_SC[Rx_AbortSignal];
+    Rx_Overflow_cp : coverpoint uin_hdlc.Rx_SC[Rx_Overflow];
+    Rx_FCSen_cp : coverpoint uin_hdlc.Rx_SC[Rx_FCSen];
+
+    // Check all bits in Tx_SC register have been toggled
+    Tx_Done_cp : coverpoint uin_hdlc.Rx_SC[Tx_Done];
+    Tx_Enable_cp : coverpoint uin_hdlc.Rx_SC[Tx_Enable];
+    Tx_AbortFrame_cp : coverpoint uin_hdlc.Rx_SC[Tx_AbortFrame];
+    Tx_AbortedTrans_cp : coverpoint uin_hdlc.Rx_SC[Tx_AbortedTrans];
+    Tx_Full_cp : coverpoint uin_hdlc.Rx_SC[Tx_Full];
 
   endgroup
 

--- a/tb/coverage_hdlc.sv
+++ b/tb/coverage_hdlc.sv
@@ -4,35 +4,34 @@
 // Date: 19.04.2025 
 //////////////////////////////////////////////////
 
+`include "hdlc_packet.sv"
+
 module coverage_hdlc(
   in_hdlc uin_hdlc
 );
   covergroup hdlc_cg @(posedge uin_hdlc.Clk);
     Tx_FrameSize_cp : coverpoint uin_hdlc.Tx_FrameSize {
-
+      bins zero = {2}; // address + control + 0 data bytes
+      bins small_ = {[3:10]};
+      bins large_ = {[100:$]};
+      bins max = {126};
+      bins others = default;
     }
 
     Rx_FrameSize_cp : coverpoint uin_hdlc.Rx_FrameSize {
-
+      bins zero = {2}; // address + control + 0 data bytes
+      bins small_ = {[3:10]};
+      bins large_ = {[100:$]};
+      bins max = {126};
+      bins others = default;
     }
 
-    Tx_SC_cp : coverpoint uin_hdlc.Tx_SC {
-
-    }
-
-    Rx_SC_cp : coverpoint uin_hdlc.Rx_SC {
-
-    }
   endgroup
 
   //Initialize coverage group
   hdlc_cg coverage_inst;
   initial begin
       coverage_inst = new();
-  end
-
-  always @(posedge uin_hdlc.Clk) begin
-    coverage_inst.sample();
   end
 
 endmodule:coverage_hdlc

--- a/tb/hdlc_packet.sv
+++ b/tb/hdlc_packet.sv
@@ -1,0 +1,26 @@
+// shared enums
+
+enum logic[2:0] {
+  Tx_SC,
+  Tx_Buff,
+  Rx_SC,
+  Rx_Buff,
+  Rx_Len
+} RegAddr;
+
+enum int {        
+  Rx_Ready,
+  Rx_Drop,
+  Rx_FrameError,
+  Rx_AbortSignal,
+  Rx_Overflow,
+  Rx_FCSen
+} RxSC_bits;
+
+enum int {        
+  Tx_Done,
+  Tx_Enable,
+  Tx_AbortFrame,
+  Tx_AbortedTrans,
+  Tx_Full
+} TxSC_bits;

--- a/tb/in_hdlc.sv
+++ b/tb/in_hdlc.sv
@@ -50,6 +50,7 @@ interface in_hdlc ();
   logic       Rx_StopFCS;
   logic       RxD;
   logic       ZeroDetect;
+  logic [7:0] Rx_SC;
 
   // Tx
   logic       Tx_AbortFrame;
@@ -59,5 +60,6 @@ interface in_hdlc ();
   logic       Tx_Enable;
   logic [7:0] Tx_FrameSize;
   logic [7:0] Tx_BufferCount;
+  logic [7:0] Tx_SC;
 
 endinterface

--- a/tb/simulate.sh
+++ b/tb/simulate.sh
@@ -17,7 +17,7 @@ then
   	echo vsim -assertdebug -voptargs="+acc" test_hdlc bind_hdlc -do "log -r *" &
   	exit
 else
-	if vsim -assertdebug -c -voptargs="+acc" test_hdlc bind_hdlc -do "log -r *; run -all; exit" 
+	if vsim -assertdebug -c -coverage -voptargs="+acc" test_hdlc bind_hdlc -do "log -r *; run -all; coverage report -cvg -assert -details -output coverage_rep.txt; exit" 
 	then
 		echo "Success"
 	else

--- a/tb/testPr_hdlc.sv
+++ b/tb/testPr_hdlc.sv
@@ -458,7 +458,6 @@ program testPr_hdlc(
     Receive( 42, 0, 0, 0, 0, 1, 0); //FrameDropped
     Receive(  6, 0, 0, 0, 0, 0, 0); //Normal
     Receive( 33, 0, 0, 1, 0, 0, 0); //FrameError NonByteAligned
-    
 
     $display("*************************************************************");
     $display("%t - Finishing Test Program", $time);

--- a/tb/testPr_hdlc.sv
+++ b/tb/testPr_hdlc.sv
@@ -17,7 +17,6 @@
    - A ReadAddress() task is provided, and addresses are documentet in the 
      HDLC Module Design Description
 */
-`include "hdlc_packet.sv"
 
 program testPr_hdlc(
   in_hdlc uin_hdlc
@@ -30,6 +29,8 @@ program testPr_hdlc(
    *                               Student code                               *
    *                                                                          *
    ****************************************************************************/
+
+  `include "hdlc_packet.sv"
   
   // VerifyAbortReceive should verify correct value in the Rx status/control
   // register, and that the Rx data buffer is zero after abort.

--- a/tb/testPr_hdlc.sv
+++ b/tb/testPr_hdlc.sv
@@ -17,6 +17,7 @@
    - A ReadAddress() task is provided, and addresses are documentet in the 
      HDLC Module Design Description
 */
+`include "hdlc_packet.sv"
 
 program testPr_hdlc(
   in_hdlc uin_hdlc
@@ -29,31 +30,6 @@ program testPr_hdlc(
    *                               Student code                               *
    *                                                                          *
    ****************************************************************************/
-
-  enum logic[2:0] {
-    Tx_SC,
-    Tx_Buff,
-    Rx_SC,
-    Rx_Buff,
-    Rx_Len
-  } RegAddr;
-
-  enum int {        
-    Rx_Ready,
-    Rx_Drop,
-    Rx_FrameError,
-    Rx_AbortSignal,
-    Rx_Overflow,
-    Rx_FCSen
-  } RxSC_bits;
-
-  enum int {        
-    Tx_Done,
-    Tx_Enable,
-    Tx_AbortFrame,
-    Tx_AbortedTrans,
-    Tx_Full
-  } TxSC_bits;
   
   // VerifyAbortReceive should verify correct value in the Rx status/control
   // register, and that the Rx data buffer is zero after abort.

--- a/tb/test_hdlc.sv
+++ b/tb/test_hdlc.sv
@@ -36,6 +36,7 @@ module test_hdlc ();
   assign uin_hdlc.Rx_StartFCS        = u_dut.Rx_StartFCS;
   assign uin_hdlc.Rx_StopFCS         = u_dut.Rx_StopFCS;
   assign uin_hdlc.RxD                = u_dut.RxD;
+  assign uin_hdlc.Rx_SC              = u_dut.u_AddressIF.Rx_SC;
   assign uin_hdlc.ZeroDetect         = u_dut.u_RxChannel.ZeroDetect;
   assign uin_hdlc.Tx_AbortFrame      = u_dut.Tx_AbortFrame;
   assign uin_hdlc.Tx_AbortedTrans    = u_dut.Tx_AbortedTrans;
@@ -43,6 +44,7 @@ module test_hdlc ();
   assign uin_hdlc.Tx_Enable          = u_dut.Tx_Enable;
   assign uin_hdlc.Tx_FrameSize       = u_dut.Tx_FrameSize;
   assign uin_hdlc.Tx_BufferCount     = u_dut.u_TxBuff.Count;
+  assign uin_hdlc.Tx_SC              = u_dut.u_AddressIF.Tx_SC;
 
   //Clock
   always #250ns uin_hdlc.Clk = ~uin_hdlc.Clk;
@@ -69,6 +71,11 @@ module test_hdlc ();
 
   //Test program
   testPr_hdlc u_testPr(
+    .uin_hdlc (uin_hdlc)
+  );
+
+  //Coverage 
+  coverage_hdlc u_coverage_hdlc(
     .uin_hdlc (uin_hdlc)
   );
 


### PR DESCRIPTION
# Changes

- Move register enums to separate file to avoid redeclaration.
- Update compilation and simulation scripts to in order to collect and log coverage.
- Add coverage group checking transmitted and received frame sizes, and that all bits in status/control registers have been toggled.
- Coverage report also collects information about the assertions, allowing us to check that all assertions have been evaluated. 